### PR TITLE
fix: Don't return nil documentation.value

### DIFF
--- a/lua/cmp_conjure/init.lua
+++ b/lua/cmp_conjure/init.lua
@@ -55,7 +55,7 @@ function source:complete(request, callback)
       table.insert(items, {
         label = completion.word,
         detail = completion.menu,
-        documentation = {
+        documentation = completion.info and {
           kind = cmp.lsp.MarkupKind.PlainText,
           value = completion.info,
         },


### PR DESCRIPTION
Spec indicates that if documentation is present, then documentation.value should be a string.
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContentInnerDefinition

See also conversation at https://github.com/Saghen/blink.cmp/pull/562